### PR TITLE
Add session management

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -25,12 +25,12 @@ type handlers struct {
 	sessions *state.SessionManager
 }
 
-// (GET /) index.html that describes this api
+// (GET /) : get docuentation index.html that describes this api
 func (h *handlers) Index(ctx echo.Context) error {
 	return ctx.HTML(http.StatusOK, documentation)
 }
 
-// (GET /cards) Get the current state of the deck
+// (GET /cards) : get the current state of the deck
 func (h *handlers) DeckShow(ctx echo.Context) error {
 	h.lock.Lock()
 	defer h.lock.Unlock()
@@ -103,7 +103,7 @@ func (h *handlers) DeckReturnCard(ctx echo.Context) error {
 	return json(ctx, http.StatusOK, fromGameCards(session.Deck.Cards))
 }
 
-// (GET /cards/return?card={card}) : return the card specified in url parameter to the back of the deck (testing helper)
+// (GET /cards/return?card={card}) : return the card specified in 'card' parameter to the back of the deck (testing helper)
 func (h *handlers) DeckReturnCard2(ctx echo.Context, params api.DeckReturnCard2Params) error {
 	if params.Card == nil {
 		return json(ctx, http.StatusBadRequest, api.Error{Message: "the required url parameter 'card' is missing"})

--- a/handlers.go
+++ b/handlers.go
@@ -76,7 +76,7 @@ func (h *handlers) DeckDealCard2(ctx echo.Context) error {
 	return h.DeckDealCard(ctx)
 }
 
-// (POST /cards/return) Return the card specified in body to the back of the deck
+// (POST /cards/return) : return the card specified in body to the back of the deck
 func (h *handlers) DeckReturnCard(ctx echo.Context) error {
 	// We expect an api.Card object in the request body
 	var c api.Card
@@ -127,7 +127,7 @@ func (h *handlers) DeckReturnCard2(ctx echo.Context, params api.DeckReturnCard2P
 	return json(ctx, http.StatusOK, fromGameCards(session.Deck.Cards))
 }
 
-// fetchSessionSetCookie will fetch or create a new session, setting the session cookie if needed
+// will fetch or create a new session, setting the session cookie if needed
 func (h *handlers) fetchSessionSetCookie(ctx echo.Context) state.Session {
 
 	createSessionSetCookie := func(ctx echo.Context) state.Session {

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -4,6 +4,6 @@ import "github.com/AntonAverchenkov/cards-http-service/internal/game"
 
 // Session represents a persistent connection with a client
 type Session struct {
-	ID   int
+	Id   string
 	Deck *game.Deck
 }

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -2,7 +2,7 @@ package state
 
 import "github.com/AntonAverchenkov/cards-http-service/internal/game"
 
-// Session represents a persistent connection with a client
+// Session represents a persistent connection with a client, each client will get their own deck
 type Session struct {
 	Id   string
 	Deck *game.Deck

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -1,0 +1,9 @@
+package state
+
+import "github.com/AntonAverchenkov/cards-http-service/internal/game"
+
+// Session represents a persistent connection with a client
+type Session struct {
+	ID   int
+	Deck *game.Deck
+}

--- a/internal/state/session_manager.go
+++ b/internal/state/session_manager.go
@@ -1,0 +1,37 @@
+package state
+
+import "github.com/AntonAverchenkov/cards-http-service/internal/game"
+
+// SessionManager maintains a collection of currently active sessions
+type SessionManager struct {
+	latest   int
+	sessions map[int]Session
+}
+
+func NewSessionManaer() *SessionManager {
+	return &SessionManager{
+		latest:   0,
+		sessions: make(map[int]Session, 0),
+	}
+}
+
+func (s *SessionManager) NewSession() Session {
+	s.latest++
+
+	var (
+		id      = s.latest
+		session = Session{
+			ID:   id,
+			Deck: game.NewDeck(),
+		}
+	)
+	s.sessions[id] = session
+
+	return session
+}
+
+func (s *SessionManager) Get(id int) (Session, bool) {
+	session, exists := s.sessions[id]
+
+	return session, exists
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/AntonAverchenkov/cards-http-service/internal/api"
-	"github.com/AntonAverchenkov/cards-http-service/internal/game"
+	"github.com/AntonAverchenkov/cards-http-service/internal/state"
 	"github.com/deepmap/oapi-codegen/pkg/middleware"
 	"github.com/jessevdk/go-flags"
 	"github.com/labstack/echo/v4"
@@ -42,7 +42,7 @@ func run(cl CommandLineOptions) (errs error) {
 	}
 
 	handlers := handlers{
-		deck: game.NewDeck(),
+		sessions: state.NewSessionManager(),
 	}
 
 	server := echo.New()


### PR DESCRIPTION
Use a cookie named `"session"` to store client-specific session id. The server maintains the list of session's in memory and has the corresponding deck object for each session.