### PR TITLE
Add session persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ The sessions are maintained by setting the session cookie. Each session
 corresponds to a single deck view. This is currently not going to work if
 the cookies are not enabled.
 
+### Session persistence
+
+The sessions can be optionally persisted through server restarts:
+
+```sh
+$ ./cards-http-service --sessions-persist-to path/to/file --sessions-restore-from path/to/file
+```
+
+If specified, the service will attempt to parse the given file on startup for
+any persisted sessions. On shutdown, the server will write sessions to the
+given file. This mechanism is not fullproof (it will not work if the service
+hard-crashes). However, this should take care of most other cases.
+
 ## Installation
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/deepmap/oapi-codegen v1.6.1
 	github.com/getkin/kin-openapi v0.53.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/labstack/echo/v4 v4.2.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,10 @@ github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tF
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/handlers.go
+++ b/handlers.go
@@ -21,7 +21,7 @@ const (
 )
 
 type handlers struct {
-	lock     sync.Mutex
+	lock     *sync.Mutex
 	sessions *state.SessionManager
 }
 

--- a/internal/game/deck.go
+++ b/internal/game/deck.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -34,6 +35,40 @@ func NewDeck() *Deck {
 		Cards: cards,
 		rng:   rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
+}
+
+func (d *Deck) Serialize() string {
+	var b strings.Builder
+
+	for _, card := range d.Cards {
+		b.WriteString(card.ShortString())
+	}
+
+	return b.String()
+}
+
+func DeckDeserialize(str string) (*Deck, error) {
+	var cards []Card
+
+	if len(str)%2 != 0 {
+		return nil, fmt.Errorf("the string length (%d) is not even", len(str))
+	}
+
+	for i := 0; i < len(str); i += 2 {
+
+		// this should not be out of range since the length is even
+		c, err := ParseCard(str[i : i+2])
+		if err != nil {
+			return nil, err
+		}
+
+		cards = append(cards, c)
+	}
+
+	return &Deck{
+		Cards: cards,
+		rng:   rand.New(rand.NewSource(time.Now().UnixNano())),
+	}, nil
 }
 
 // DealCard removes the top card from the deck (subtracts it from the slice's front) and returns it

--- a/internal/game/deck_test.go
+++ b/internal/game/deck_test.go
@@ -89,3 +89,36 @@ func TestDeckReturn(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, deck.ReturnCard(Card{Value: ValueAce, Suit: SuitSpades}))
 }
+
+func TestSerializeDeserialize(t *testing.T) {
+	_, err := DeckDeserialize("ahq")
+	require.Error(t, err)
+
+	_, err = DeckDeserialize("ahqs3")
+	require.Error(t, err)
+
+	_, err = DeckDeserialize("ahqs3m")
+	require.Error(t, err)
+
+	expected := []Card{{
+		Value: ValueAce,
+		Suit:  SuitHearts,
+	}, {
+		Value: ValueQueen,
+		Suit:  SuitSpades,
+	}, {
+		Value: ValueThree,
+		Suit:  SuitDiamonds,
+	}, {
+		Value: ValueJack,
+		Suit:  SuitSpades,
+	}, {
+		Value: ValueTen,
+		Suit:  SuitClubs,
+	}}
+
+	deck, err := DeckDeserialize("ahqs3djstc")
+	require.NoError(t, err)
+	require.Equal(t, expected, deck.Cards)
+	require.Equal(t, "ahqs3djstc", deck.Serialize())
+}

--- a/internal/state/persist_restore.go
+++ b/internal/state/persist_restore.go
@@ -1,0 +1,77 @@
+package state
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AntonAverchenkov/cards-http-service/internal/game"
+	"github.com/hashicorp/go-multierror"
+)
+
+// Persist will write sessions information to the given file
+func (s *SessionManager) Persist(path string) (errs error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("could not create %q: %w", path, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("could not close %q: %w", path, err))
+		}
+	}()
+
+	for _, session := range s.sessions {
+		if _, err := fmt.Fprintf(f, "%s %s\n", session.Id, session.Deck.Serialize()); err != nil {
+			return fmt.Errorf("could not write to %q file: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+// Restore will restore sessions from the given file
+func Restore(path string) (_ *SessionManager, errs error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %q: %w", path, err)
+	}
+	defer func() {
+		if err = f.Close(); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("could not close %q: %w", path, err))
+		}
+	}()
+
+	scanner := bufio.NewScanner(f)
+
+	sessions := make(map[string]Session, 0)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		tokens := strings.Split(line, " ")
+
+		if len(tokens) != 2 {
+			return nil, fmt.Errorf("%q has incorrect number of tokens", path)
+		}
+
+		deck, err := game.DeckDeserialize(tokens[1])
+		if err != nil {
+			return nil, fmt.Errorf("%q: deck could not be parsed: %w", path, err)
+		}
+
+		sessions[tokens[0]] = Session{
+			Id:   tokens[0],
+			Deck: deck,
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("could not read %q %w", path, err)
+	}
+
+	return &SessionManager{
+		sessions: sessions,
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -39,8 +39,8 @@ func main() {
 }
 
 func run(cl CommandLineOptions) (errs error) {
-	/* */ log.Printf("run(): cards-http-service begin")
-	defer log.Printf("run(): cards-http-service end")
+	/* */ log.Println("run(): cards-http-service begin")
+	defer log.Println("run(): cards-http-service end")
 
 	signalled := make(chan os.Signal, 1)
 	signal.Notify(
@@ -60,11 +60,12 @@ func run(cl CommandLineOptions) (errs error) {
 		sessions *state.SessionManager
 	)
 	if cl.SessionsRestoreFrom != "" {
-		log.Printf("run(): restoring sessions from %q", cl.SessionsRestoreFrom)
+		log.Printf("run(): restoring sessions from %q\n", cl.SessionsRestoreFrom)
 
 		sessions, err = state.Restore(cl.SessionsRestoreFrom)
 		if err != nil {
-			return fmt.Errorf("could not restore: %w", err)
+			log.Printf("run(): could not restore sessions; starting new ones: %v\n", err)
+			sessions = state.NewSessionManager()
 		}
 	} else {
 		sessions = state.NewSessionManager()
@@ -88,19 +89,19 @@ func run(cl CommandLineOptions) (errs error) {
 		close(done)
 	}()
 
-	// block until an interrupt signal or the server exit
+	// block until an interrupt signal or server exit
 	select {
 	case <-signalled:
-		log.Printf("run(): signalled, exiting")
+		log.Println("run(): signalled, exiting")
 	case <-done:
-		log.Printf("run(): the server has stopped")
+		log.Println("run(): the server has stopped")
 	}
 
 	if cl.SessionsPersistTo != "" {
 		lock.Lock()
 		defer lock.Unlock()
 
-		log.Printf("run(): persisting sessions to %q", cl.SessionsPersistTo)
+		log.Printf("run(): persisting sessions to %q\n", cl.SessionsPersistTo)
 
 		if err := sessions.Persist(cl.SessionsPersistTo); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("could not persist: %w", err))

--- a/main.go
+++ b/main.go
@@ -4,16 +4,22 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	"github.com/AntonAverchenkov/cards-http-service/internal/api"
 	"github.com/AntonAverchenkov/cards-http-service/internal/state"
 	"github.com/deepmap/oapi-codegen/pkg/middleware"
+	"github.com/hashicorp/go-multierror"
 	"github.com/jessevdk/go-flags"
 	"github.com/labstack/echo/v4"
 )
 
 type CommandLineOptions struct {
-	Address string `long:"address"  env:"ADDRESS"  description:"Listen to http traffic on this tcp address"   default:"localhost:8080"`
+	Address             string `long:"address"                env:"ADDRESS"                description:"Listen to http traffic on this tcp address"      default:"localhost:8080"`
+	SessionsPersistTo   string `long:"sessions-persist-to"    env:"SESSIONS_PERSIST_TO"    description:"Persist the sessions to this file on exit"       default:""`
+	SessionsRestoreFrom string `long:"sessions-restore-from"  env:"SESSIONS_RESTORE_FROM"  description:"Restore the sessions from this file on startup"  default:""`
 }
 
 func main() {
@@ -36,13 +42,37 @@ func run(cl CommandLineOptions) (errs error) {
 	/* */ log.Printf("run(): cards-http-service begin")
 	defer log.Printf("run(): cards-http-service end")
 
+	signalled := make(chan os.Signal, 1)
+	signal.Notify(
+		signalled,
+		syscall.SIGHUP,  // sent to the process when its controlling terminal is closed
+		syscall.SIGINT,  // sent to the process by its controlling terminal when a user wishes to interrupt the process
+		syscall.SIGTERM, // sent to the process to request its termination
+	)
+
 	swagger, err := api.GetSwagger()
 	if err != nil {
 		return fmt.Errorf("could not load swagger spec: %w", err)
 	}
 
+	var (
+		lock     sync.Mutex
+		sessions *state.SessionManager
+	)
+	if cl.SessionsRestoreFrom != "" {
+		log.Printf("run(): restoring sessions from %q", cl.SessionsRestoreFrom)
+
+		sessions, err = state.Restore(cl.SessionsRestoreFrom)
+		if err != nil {
+			return fmt.Errorf("could not restore: %w", err)
+		}
+	} else {
+		sessions = state.NewSessionManager()
+	}
+
 	handlers := handlers{
-		sessions: state.NewSessionManager(),
+		lock:     &lock,
+		sessions: sessions,
 	}
 
 	server := echo.New()
@@ -52,8 +82,29 @@ func run(cl CommandLineOptions) (errs error) {
 
 	log.Printf("run(): starting to listen & serve on %q\n", cl.Address)
 
-	if err := server.Start(cl.Address); err != nil {
-		return fmt.Errorf("could not start the server @ %q: %w", cl.Address, err)
+	done := make(chan bool)
+	go func() {
+		server.Start(cl.Address)
+		close(done)
+	}()
+
+	// block until an interrupt signal or the server exit
+	select {
+	case <-signalled:
+		log.Printf("run(): signalled, exiting")
+	case <-done:
+		log.Printf("run(): the server has stopped")
+	}
+
+	if cl.SessionsPersistTo != "" {
+		lock.Lock()
+		defer lock.Unlock()
+
+		log.Printf("run(): persisting sessions to %q", cl.SessionsPersistTo)
+
+		if err := sessions.Persist(cl.SessionsPersistTo); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("could not persist: %w", err))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The sessions can be optionally persisted through server restarts:

```sh
$ ./cards-http-service --sessions-persist-to path/to/file --sessions-restore-from path/to/file
```

If specified, the service will attempt to parse the given file on startup for
any persisted sessions. On shutdown, the server will write sessions to the
given file. This mechanism is not fullproof (it will not work if the service
hard-crashes). However, this should take care of most other cases.